### PR TITLE
[env] Set codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# https://docs.github.com/ja/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Global default
+* @y047aka @pxfnc @tsukimizake


### PR DESCRIPTION
In order to reduce the effort when opening a Pull Request, we will set up code owners.
Pull Requestをオープンする際の手間を減らすために、コードオーナーを設定します。