### PR TITLE
[package] Study for package

### DIFF
--- a/package/elm.json
+++ b/package/elm.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "version": "0.0.0",
     "exposed-modules": [
-        "Config"
+        "Emaki.Props"
     ],
     "elm-version": "0.19.1 <= v < 0.20.0",
     "dependencies": {

--- a/package/elm.json
+++ b/package/elm.json
@@ -1,0 +1,16 @@
+{
+    "type": "package",
+    "name": "y047aka/emaki",
+    "summary": "TODO",
+    "license": "MIT",
+    "version": "0.0.0",
+    "exposed-modules": [
+        "Config"
+    ],
+    "elm-version": "0.19.1 <= v < 0.20.0",
+    "dependencies": {
+        "elm/core": "1.0.5 <= v < 2.0.0",
+        "elm/html": "1.0.0 <= v < 2.0.0"
+    },
+    "test-dependencies": {}
+}

--- a/package/elm.json
+++ b/package/elm.json
@@ -10,7 +10,7 @@
     "elm-version": "0.19.1 <= v < 0.20.0",
     "dependencies": {
         "elm/core": "1.0.5 <= v < 2.0.0",
-        "elm/html": "1.0.0 <= v < 2.0.0"
+        "rtfeldman/elm-css": "18.0.0 <= v < 19.0.0"
     },
     "test-dependencies": {}
 }

--- a/package/src/Config.elm
+++ b/package/src/Config.elm
@@ -1,0 +1,157 @@
+module Config exposing
+    ( Config, render
+    , string, bool, select, counter
+    , list, fieldset
+    , field
+    )
+
+{-|
+
+@docs Config, render
+@docs string, bool, select, counter
+@docs list, fieldset
+@docs field
+
+-}
+
+import Html exposing (Html, button, div, input, legend, text)
+import Html.Attributes exposing (checked, placeholder, selected, type_, value)
+import Html.Events exposing (onInput)
+
+
+type Config msg
+    = String (StringProps msg)
+    | Bool (BoolProps msg)
+    | Select (SelectProps msg)
+    | Radio (RadioProps msg)
+    | Counter (CounterProps msg)
+    | List (List (Config msg))
+    | FieldSet String (List (Config msg))
+    | Field String (Config msg)
+
+
+type alias StringProps msg =
+    { value : String
+    , onInput : String -> msg
+    , placeholder : String
+    }
+
+
+type alias BoolProps msg =
+    { value : Bool, onClick : msg }
+
+
+type alias SelectProps msg =
+    { value : String
+    , options : List String
+    , onChange : String -> msg
+    }
+
+
+type alias RadioProps msg =
+    { value : String
+    , options : List String
+    , onChange : String -> msg
+    }
+
+
+type alias CounterProps msg =
+    { value : Float
+    , onClickPlus : msg
+    , onClickMinus : msg
+    }
+
+
+render : Config msg -> Html msg
+render config =
+    case config of
+        String props ->
+            input
+                [ type_ "text"
+                , value props.value
+                , onInput props.onInput
+                , placeholder props.placeholder
+                ]
+                []
+
+        Bool props ->
+            input [ type_ "checkbox", checked props.value ] []
+
+        Select props ->
+            Html.select [ onInput props.onChange ]
+                (List.map (\option -> Html.option [ value option, selected (props.value == option) ] [ text option ])
+                    props.options
+                )
+
+        Radio props ->
+            Html.fieldset []
+                (List.map
+                    (\option ->
+                        Html.label []
+                            [ input
+                                [ type_ "radio"
+                                , value option
+                                , checked (props.value == option)
+                                , onInput props.onChange
+                                ]
+                                []
+                            ]
+                    )
+                    props.options
+                )
+
+        Counter props ->
+            div []
+                [ button [] [ text "-" ]
+                , text (String.fromFloat props.value)
+                , button [] [ text "+" ]
+                ]
+
+        List configs ->
+            div [] (List.map render configs)
+
+        FieldSet label configs ->
+            Html.fieldset [] <|
+                legend [] [ text label ]
+                    :: List.map render configs
+
+        Field label config_ ->
+            div []
+                [ Html.label [] [ text label ]
+                , render config_
+                ]
+
+
+string : StringProps msg -> Config msg
+string =
+    String
+
+
+bool : BoolProps msg -> Config msg
+bool =
+    Bool
+
+
+select : SelectProps msg -> Config msg
+select =
+    Select
+
+
+counter : CounterProps msg -> Config msg
+counter =
+    Counter
+
+
+list : List (Config msg) -> Config msg
+list =
+    List
+
+
+fieldset : String -> List (Config msg) -> Config msg
+fieldset =
+    FieldSet
+
+
+field : String -> Config msg -> Config msg
+field =
+    Field

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -1,5 +1,5 @@
 module Emaki.Props exposing
-    ( Config, render
+    ( Props, render
     , string, bool, select, counter
     , list, fieldset
     , field
@@ -7,7 +7,7 @@ module Emaki.Props exposing
 
 {-|
 
-@docs Config, render
+@docs Props, render
 @docs string, bool, select, counter
 @docs list, fieldset
 @docs field
@@ -19,15 +19,15 @@ import Html.Attributes exposing (checked, placeholder, selected, type_, value)
 import Html.Events exposing (onInput)
 
 
-type Config msg
+type Props msg
     = String (StringProps msg)
     | Bool (BoolProps msg)
     | Select (SelectProps msg)
     | Radio (RadioProps msg)
     | Counter (CounterProps msg)
-    | List (List (Config msg))
-    | FieldSet String (List (Config msg))
-    | Field String (Config msg)
+    | List (List (Props msg))
+    | FieldSet String (List (Props msg))
+    | Field String (Props msg)
 
 
 type alias StringProps msg =
@@ -62,28 +62,28 @@ type alias CounterProps msg =
     }
 
 
-render : Config msg -> Html msg
-render config =
-    case config of
-        String props ->
+render : Props msg -> Html msg
+render props =
+    case props of
+        String ps ->
             input
                 [ type_ "text"
-                , value props.value
-                , onInput props.onInput
-                , placeholder props.placeholder
+                , value ps.value
+                , onInput ps.onInput
+                , placeholder ps.placeholder
                 ]
                 []
 
-        Bool props ->
-            input [ type_ "checkbox", checked props.value ] []
+        Bool ps ->
+            input [ type_ "checkbox", checked ps.value ] []
 
-        Select props ->
-            Html.select [ onInput props.onChange ]
-                (List.map (\option -> Html.option [ value option, selected (props.value == option) ] [ text option ])
-                    props.options
+        Select ps ->
+            Html.select [ onInput ps.onChange ]
+                (List.map (\option -> Html.option [ value option, selected (ps.value == option) ] [ text option ])
+                    ps.options
                 )
 
-        Radio props ->
+        Radio ps ->
             Html.fieldset []
                 (List.map
                     (\option ->
@@ -91,67 +91,67 @@ render config =
                             [ input
                                 [ type_ "radio"
                                 , value option
-                                , checked (props.value == option)
-                                , onInput props.onChange
+                                , checked (ps.value == option)
+                                , onInput ps.onChange
                                 ]
                                 []
                             ]
                     )
-                    props.options
+                    ps.options
                 )
 
-        Counter props ->
+        Counter ps ->
             div []
                 [ button [] [ text "-" ]
-                , text (String.fromFloat props.value)
+                , text (String.fromFloat ps.value)
                 , button [] [ text "+" ]
                 ]
 
-        List configs ->
-            div [] (List.map render configs)
+        List childProps ->
+            div [] (List.map render childProps)
 
-        FieldSet label configs ->
+        FieldSet label childProps ->
             Html.fieldset [] <|
                 legend [] [ text label ]
-                    :: List.map render configs
+                    :: List.map render childProps
 
-        Field label config_ ->
+        Field label ps ->
             div []
                 [ Html.label [] [ text label ]
-                , render config_
+                , render ps
                 ]
 
 
-string : StringProps msg -> Config msg
+string : StringProps msg -> Props msg
 string =
     String
 
 
-bool : BoolProps msg -> Config msg
+bool : BoolProps msg -> Props msg
 bool =
     Bool
 
 
-select : SelectProps msg -> Config msg
+select : SelectProps msg -> Props msg
 select =
     Select
 
 
-counter : CounterProps msg -> Config msg
+counter : CounterProps msg -> Props msg
 counter =
     Counter
 
 
-list : List (Config msg) -> Config msg
+list : List (Props msg) -> Props msg
 list =
     List
 
 
-fieldset : String -> List (Config msg) -> Config msg
+fieldset : String -> List (Props msg) -> Props msg
 fieldset =
     FieldSet
 
 
-field : String -> Config msg -> Config msg
+field : String -> Props msg -> Props msg
 field =
     Field

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -1,4 +1,4 @@
-module Config exposing
+module Emaki.Props exposing
     ( Config, render
     , string, bool, select, counter
     , list, fieldset

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -14,9 +14,9 @@ module Emaki.Props exposing
 
 -}
 
-import Html exposing (Html, button, div, input, legend, text)
-import Html.Attributes exposing (checked, placeholder, selected, type_, value)
-import Html.Events exposing (onInput)
+import Html.Styled as Html exposing (Html, button, div, input, legend, text)
+import Html.Styled.Attributes exposing (checked, placeholder, selected, type_, value)
+import Html.Styled.Events exposing (onInput)
 
 
 type Props msg


### PR DESCRIPTION
Elm packageにて公開するAPIのための検討に着手。
ここでは、従来の [rio-grande](https://github.com/y047aka/rio-grande/blob/main/src/ConfigAndPreview.elm) の実装から config を扱う部分を切り出して `Config.elm` として試作しました。

I have started considering the Elm package's API for publication. 
Here, I have prototyped the part that deals with the configuration from the past [Playground.elm](https://github.com/y047aka/rio-grande/blob/main/src/ConfigAndPreview.elm) as `Config.elm` .

